### PR TITLE
Fix dashboard, prefer ipv4 for java, forward 5556 for dashboard access t...

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Runs the following processes:
 	- collectd: 		submits stats to the localhost
 	- carbon-c-relay:	takes graphite input and sends a copy to riemann
 	- riemann:		runs the riemann monitoring server with a basic configuration
+	- nginx:	        client system runs Nginx	
+	- logstash:	        takes nginx input and sends events to riemann	
 
 data flow
 ---------
@@ -25,10 +27,12 @@ data flow
         +----------+       | Riemann Server                 |
         |  Nodes   |       |                                |
         | collectd +-------->carbon-c-relay (port 2003)     |
-        +----------+       |            +                   |
-                           |            |                   |
-                           |            v                   |
-                           | riemann (graphite port 2004)   |
+        |  nginx   |       |            +                   |
+        | logstash +---+   |            |                   |
+        +----------+   |   |            |                   |
+                       |   |            |                   |
+                       |   |            v                   |
+                       +---->riemann (graphite port 2004)   |
                            |                                |
                            +------------+-------------------+
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     server.vm.host_name = 'riemann'
     server.vm.network "forwarded_port", guest: 4567, host: 4567
     server.vm.network "forwarded_port", guest: 5555, host: 5555
+    server.vm.network "forwarded_port", guest: 5556, host: 5556
     server.vm.network "private_network", ip: "172.16.3.101"
     server.vm.synced_folder "puppet/modules", "/tmp/vagrant-puppet/puppet/modules"
     server.vm.provision :puppet do |puppet|

--- a/puppet/modules/riemann/manifests/packages.pp
+++ b/puppet/modules/riemann/manifests/packages.pp
@@ -42,12 +42,12 @@ class riemann::packages inherits riemann {
     require => Package['ruby1.9.1'],
   }
 
-  #  $gemlist=['riemann-client', 'riemann-tools', 'riemann-dash']
-  #
-  #  package { $gemlist:
-  #    ensure   => installed,
-  #    provider => gem,
-  #    require  => Package['ruby1.9.1-dev'],
-  #  }
+  $gemlist=['riemann-client', 'riemann-tools', 'riemann-dash']
+ 
+  package { $gemlist:
+    ensure   => installed,
+    provider => gem,
+    require  => Package['ruby1.9.1-dev'],
+  }
 
 }

--- a/puppet/modules/riemann/manifests/services.pp
+++ b/puppet/modules/riemann/manifests/services.pp
@@ -3,17 +3,17 @@ class riemann::services inherits riemann {
   include runit
 
   runit::services::runner { 'riemann':
-    runner_command => 'bin/riemann etc/riemann.config',
+    runner_command => 'bin/riemann etc/riemann.config -Djava.net.preferIPv4Stack=true',
     runner_rundir  => '/opt/riemann',
     runner_log_dir => '/var/log/riemann',
     require        => Class['riemann::configure', 'riemann::packages'],
   }
 
-  #  runit::services::runner { 'riemann-dash':
-  #    runner_command => '/usr/local/bin/riemann-dash /opt/riemann/etc/dashboard.config',
-  #    runner_rundir  => '/opt/riemann',
-  #    runner_log_dir => '/var/log/riemann-dash',
-  #    require        => Class['riemann::configure', 'riemann::packages'],
-  #  }
+  runit::services::runner { 'riemann-dash':
+    runner_command => '/usr/local/bin/riemann-dash /opt/riemann/etc/dashboard.config',
+    runner_rundir  => '/opt/riemann',
+    runner_log_dir => '/var/log/riemann-dash',
+    require        => Class['riemann::configure', 'riemann::packages'],
+  }
 
 }


### PR DESCRIPTION
Enabling dashboard required IPv4 preferred option for reimann java process, also needed to forward port 5556 so dashboard js could get to reimann socket